### PR TITLE
backup.sh执行目录兼容性更新

### DIFF
--- a/template/backup.sh
+++ b/template/backup.sh
@@ -142,11 +142,11 @@ if [[ "${DASHBOARD_UPDATE}${CLOUDFLARED_UPDATE}${IS_BACKUP}${FORCE_UPDATE}" =~ t
     [ -d /tmp/$GH_REPO ] && rm -rf /tmp/$GH_REPO
     git clone https://$GH_PAT@github.com/$GH_BACKUP_USER/$GH_REPO.git --depth 1 --quiet /tmp/$GH_REPO
 
-    # 压缩备份数据，只备份 data/ 目录下的 config.yaml 和 sqlite.db； resource/ 目录下名字有 custom 的自定义主题文件夹
+    # 压缩备份数据，只备份 $WORK_DIR/data/ 目录下的 config.yaml 和 sqlite.db； $WORK_DIR/resource/ 目录下名字有 custom 的自定义主题文件夹
     if [ -d /tmp/$GH_REPO ]; then
       TIME=$(date "+%Y-%m-%d-%H:%M:%S")
       echo "↓↓↓↓↓↓↓↓↓↓ dashboard-$TIME.tar.gz list ↓↓↓↓↓↓↓↓↓↓"
-      find resource/ -type d -name "*custom*" | tar czvf /tmp/$GH_REPO/dashboard-$TIME.tar.gz -T- data/
+      find $WORK_DIR/resource/ -type d -name "*custom*" | tar czvf /tmp/$GH_REPO/dashboard-$TIME.tar.gz -T- $WORK_DIR/data/
       echo -e "↑↑↑↑↑↑↑↑↑↑ dashboard-$TIME.tar.gz list ↑↑↑↑↑↑↑↑↑↑\n\n"
 
       # 更新备份 Github 库，删除 5 天前的备份


### PR DESCRIPTION
修复在非 ${WORK_DIR} 目录下执行 bash  ${WORK_DIR}/backup.sh 不能准备备份问题