### PR TITLE
Fixed the issue where Nezha agent could not be used after restoring data from backup

### DIFF
--- a/template/restore.sh
+++ b/template/restore.sh
@@ -156,7 +156,7 @@ if [ -e $TEMP_DIR/backup.tar.gz ]; then
   if [ "$IS_DOCKER" = 1 ]; then
     [ $(type -p sqlite3) ] || apt-get -y install sqlite3
     DB_TOKEN=$(sqlite3 ${TEMP_DIR}/${FILE_PATH}data/sqlite.db "select secret from servers where created_at='2023-04-23 13:02:00.770756566+08:00'")
-    [ -n "$DB_TOKEN" ] && LOCAL_TOKEN=$(awk '/nezha-agent -s localhost/{print $NF}' /etc/supervisor/conf.d/damon.conf)
+    [ -n "$DB_TOKEN" ] && LOCAL_TOKEN=$(awk '/nezha-agent -s localhost/{print $(NF-1)}' /etc/supervisor/conf.d/damon.conf)
     [ "$DB_TOKEN" != "$LOCAL_TOKEN" ] && sqlite3 ${TEMP_DIR}/${FILE_PATH}data/sqlite.db "update servers set secret='${LOCAL_TOKEN}' where created_at='2023-04-23 13:02:00.770756566+08:00'"
   fi
 


### PR DESCRIPTION
恢复备份后面板agent用不了的原因找到了：
![屏幕截图 2024-11-30 221120](https://github.com/user-attachments/assets/0f47f18f-3890-4c35-99c9-5ef4c5428565)
$NF在awk中是指总字段数，原来没加禁止更新的时候密钥就是最后一个字段所以没问题，现在加了禁止更新就不行了，要设置为NF-1使他输出前一个字段才可以用。已修改，测试可用，申请合并
